### PR TITLE
Add puppetlabs/augeas_core dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -63,6 +63,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.0 < 10.0.0"
+    },
+    {
+      "name": "puppetlabs/augeas_core",
+      "version_requirement": ">= 1.5.0 < 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
If the `puppetlabs/augeas_core` module is not installed, I get the following error when trying to add a port to a zone:

`Error: Evaluation Error: Resource type not found: Augeas (file: /etc/puppetlabs/code/modules/firewalld/manifests/init.pp, line: 319, column: 3)`

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds the `puppetlabs/augeas_core` module as a dependency.